### PR TITLE
Fix stack overflow crash when sending JSON payload

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/go-http-utils/headers"
@@ -16,6 +18,7 @@ type RequestEcho struct {
 	URL    string
 	Method string
 	Header http.Header
+	Body   *string
 }
 
 func TestClientGet(t *testing.T) {
@@ -41,14 +44,64 @@ func TestClientGet(t *testing.T) {
 	require.Equal(t, DefaultAcceptEncoding, echo.Header.Get(headers.AcceptEncoding))
 }
 
+func TestClientPut(t *testing.T) {
+	srv := newEchoHTTPServer()
+	defer srv.Close()
+
+	payload := struct {
+		ID     string
+		Amount int
+	}{
+		"c8c9e607-219c-4b29-b161-474d4a331651", 2000,
+	}
+
+	request := Put("transfer/").WithJSONPayload(payload)
+
+	client := NewClient(WithBaseURL(srv.URL))
+
+	response, err := client.Do(context.Background(), request)
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, response.StatusCode)
+
+	echo := RequestEcho{}
+
+	err = response.Unmarshal(&echo)
+	require.NoError(t, err)
+	require.Equal(t, "/transfer/", echo.URL)
+	require.Equal(t, http.MethodPut, echo.Method)
+	require.Equal(t, DefaultUserAgent, echo.Header.Get(headers.UserAgent))
+	require.Equal(t, DefaultAcceptEncoding, echo.Header.Get(headers.AcceptEncoding))
+	require.Equal(t, "application/json", echo.Header.Get(headers.ContentType))
+
+	require.NotNil(t, echo.Body)
+	require.Equal(t,
+		`{"ID":"c8c9e607-219c-4b29-b161-474d4a331651","Amount":2000}`,
+		strings.TrimSuffix(*echo.Body, "\n"),
+	)
+}
+
 // newEchoHTTPServer returns a new server which echos back the request as response.
 func newEchoHTTPServer() *httptest.Server {
 	handler := http.NewServeMux()
 	handler.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {
+		var body *string
+		if r.ContentLength != 0 {
+			bytes, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				rw.WriteHeader(http.StatusInternalServerError)
+				fmt.Fprintf(rw, `{"error": "%s"}`, err)
+			}
+
+			str := string(bytes)
+			body = &str
+		}
+
 		echo := RequestEcho{
 			URL:    r.URL.String(),
 			Method: r.Method,
 			Header: r.Header,
+			Body:   body,
 		}
 
 		if err := json.NewEncoder(rw).Encode(echo); err != nil {

--- a/client/request.go
+++ b/client/request.go
@@ -131,7 +131,7 @@ func (jp *jsonPayload) Read(p []byte) (n int, err error) {
 		}
 	}
 
-	return jp.Read(p)
+	return jp.buffer.Read(p)
 }
 
 func (r *Request) WithJSONPayload(payload interface{}) *Request {


### PR DESCRIPTION
This PR fixes an issue when using any of the request methods with a JSON payload.

Added a test case for sending a simple PUT request.