### PR TITLE
Added specific handlers for gorilla/mux servers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/SKF/go-utility/v2 v2.12.0
 	github.com/go-http-utils/headers v0.0.0-20181008091004-fed159eddc2a
+	github.com/gorilla/mux v1.8.0
 	github.com/jtacoma/uritemplates v1.0.0
 	github.com/stretchr/testify v1.6.1
 	go.opencensus.io v0.22.5

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,7 @@ github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/server/gorillamux/handlers.go
+++ b/server/gorillamux/handlers.go
@@ -1,0 +1,42 @@
+package gorillamux
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/mux"
+
+	"github.com/SKF/go-rest-utility/problems"
+	handlerproblems "github.com/SKF/go-rest-utility/server/gorillamux/problems"
+)
+
+func MethodNotFoundHandler(router mux.Router) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		allowedMethods := []string{}
+
+		router.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error { //nolint: errcheck
+			var match mux.RouteMatch
+			matched := route.Match(r, &match)
+			if matched || match.MatchErr == mux.ErrMethodMismatch {
+				if methods, err := route.GetMethods(); err == nil {
+					allowedMethods = append(allowedMethods, methods...)
+				}
+			}
+			return nil
+		})
+
+		w.Header().Set("Allow", strings.Join(allowedMethods, ","))
+
+		problem := handlerproblems.MethodNotAllowed(
+			r.Method,
+			allowedMethods...,
+		)
+		problems.WriteResponse(r.Context(), problem, w, r)
+	}
+}
+
+func NotFoundHandler(problem problems.Problem) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		problems.WriteResponse(r.Context(), problem, w, r)
+	}
+}

--- a/server/gorillamux/handlers.go
+++ b/server/gorillamux/handlers.go
@@ -10,7 +10,7 @@ import (
 	handlerproblems "github.com/SKF/go-rest-utility/server/gorillamux/problems"
 )
 
-func MethodNotFoundHandler(router mux.Router) http.HandlerFunc {
+func MethodNotFoundHandler(router *mux.Router) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		allowedMethods := []string{}
 
@@ -35,8 +35,8 @@ func MethodNotFoundHandler(router mux.Router) http.HandlerFunc {
 	}
 }
 
-func NotFoundHandler(problem problems.Problem) http.HandlerFunc {
+func NotFoundHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		problems.WriteResponse(r.Context(), problem, w, r)
+		problems.WriteResponse(r.Context(), handlerproblems.NotFound(), w, r)
 	}
 }

--- a/server/gorillamux/handlers_test.go
+++ b/server/gorillamux/handlers_test.go
@@ -1,0 +1,53 @@
+package gorillamux
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/SKF/go-rest-utility/server/gorillamux/problems"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_MethodNotFoundHandler(t *testing.T) {
+	expectedRes := problems.MethodNotAllowed("GET", "PUT", "POST")
+
+	router := mux.NewRouter()
+	router.Name("testRouter").Methods("PUT", "POST")
+
+	ts := httptest.NewServer(MethodNotFoundHandler(router))
+	defer ts.Close()
+	res, err := http.Get(ts.URL)
+
+	require.NoError(t, err)
+
+	reader := res.Body
+	defer reader.Close()
+
+	actual := problems.MethodNotAllowedProblem{}
+
+	require.NoError(t, json.NewDecoder(reader).Decode(&actual))
+	assert.Equal(t, expectedRes, actual)
+
+}
+
+func Test_NotFoundHandler(t *testing.T) {
+	expectedRes := problems.NotFound()
+
+	ts := httptest.NewServer(NotFoundHandler())
+	defer ts.Close()
+	res, err := http.Get(ts.URL)
+
+	require.NoError(t, err)
+
+	reader := res.Body
+	defer reader.Close()
+
+	actual := problems.NotFoundProblem{}
+
+	require.NoError(t, json.NewDecoder(reader).Decode(&actual))
+	assert.Equal(t, expectedRes, actual)
+}

--- a/server/gorillamux/handlers_test.go
+++ b/server/gorillamux/handlers_test.go
@@ -32,6 +32,7 @@ func Test_MethodNotFoundHandler(t *testing.T) {
 
 	require.NoError(t, json.NewDecoder(reader).Decode(&actual))
 	assert.Equal(t, expectedRes, actual)
+	assert.Equal(t, expectedRes.Status, res.StatusCode)
 }
 
 func Test_NotFoundHandler(t *testing.T) {
@@ -50,4 +51,5 @@ func Test_NotFoundHandler(t *testing.T) {
 
 	require.NoError(t, json.NewDecoder(reader).Decode(&actual))
 	assert.Equal(t, expectedRes, actual)
+	assert.Equal(t, expectedRes.Status, res.StatusCode)
 }

--- a/server/gorillamux/handlers_test.go
+++ b/server/gorillamux/handlers_test.go
@@ -6,10 +6,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/SKF/go-rest-utility/server/gorillamux/problems"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/SKF/go-rest-utility/server/gorillamux/problems"
 )
 
 func Test_MethodNotFoundHandler(t *testing.T) {
@@ -31,7 +32,6 @@ func Test_MethodNotFoundHandler(t *testing.T) {
 
 	require.NoError(t, json.NewDecoder(reader).Decode(&actual))
 	assert.Equal(t, expectedRes, actual)
-
 }
 
 func Test_NotFoundHandler(t *testing.T) {

--- a/server/gorillamux/problems/docs/request-method-not-allowed.md
+++ b/server/gorillamux/problems/docs/request-method-not-allowed.md
@@ -5,18 +5,14 @@
 The API endpoint did not accept the `HTTP` method that you requested. Verify that,
 
 -   The endpoint you tried to call exists in the specification.
--   The `method` in the problem matches the one in the specification.
+-   The `requestedMethod` in the problem matches the one in the specification.
 
 ## Fields
 
-|           |                                                                                       |
-| --------- | ------------------------------------------------------------------------------------- |
-| `method`  | The requested method that is not allowed                                              |
-| `allowed` | List of all accepted methods for this endpoint. Same as provided the `Accept` header. |
-| `type`    | Path to this page                                                                     |
-| `title`   | The title of this Problem                                                             |
-| `status`  | HTTP status code that is returned with this Problem                                   |
-| `detail`  | Message about why this Problem was returned                                           |
+|                    |                                                                                       |
+| ------------------ | ------------------------------------------------------------------------------------- |
+| `requestedMethod`  | The requested method that is not allowed                                              |
+| `allowedMethods`   | List of all accepted methods for this endpoint. Same as provided the `Accept` header. |
 
 ## Example
 
@@ -26,7 +22,7 @@ The API endpoint did not accept the `HTTP` method that you requested. Verify tha
     "title": "The requested method is not allowed.",
     "status": 405,
     "detail": "The requested resource does not support method 'PATCH', it does only support one of 'GET, POST, PUT, DELETE'.",
-    "method": "PATCH",
-    "allowed": ["GET", "POST", "PUT", "DELETE"]
+    "requestedMethod": "PATCH",
+    "allowedMethods": ["GET", "POST", "PUT", "DELETE"]
 }
 ```

--- a/server/gorillamux/problems/docs/request-method-not-allowed.md
+++ b/server/gorillamux/problems/docs/request-method-not-allowed.md
@@ -4,8 +4,8 @@
 
 The API endpoint did not accept the `HTTP` method that you requested. Verify that,
 
--   The endpoint you tried to call exists in the [specification](/v2/swagger).
--   The `method` in the problem matches the one in the [specification](/v2/swagger).
+-   The endpoint you tried to call exists in the specification.
+-   The `method` in the problem matches the one in the specification.
 
 ## Fields
 
@@ -13,6 +13,10 @@ The API endpoint did not accept the `HTTP` method that you requested. Verify tha
 | --------- | ------------------------------------------------------------------------------------- |
 | `method`  | The requested method that is not allowed                                              |
 | `allowed` | List of all accepted methods for this endpoint. Same as provided the `Accept` header. |
+| `type`    | Path to this page                                                                     |
+| `title`   | The title of this Problem                                                             |
+| `status`  | HTTP status code that is returned with this Problem                                   |
+| `detail`  | Message about why this Problem was returned                                           |
 
 ## Example
 

--- a/server/gorillamux/problems/docs/request-method-not-allowed.md
+++ b/server/gorillamux/problems/docs/request-method-not-allowed.md
@@ -1,0 +1,28 @@
+[< Index](/problems)
+
+# The requested method is not allowed
+
+The API endpoint did not accept the `HTTP` method that you requested. Verify that,
+
+-   The endpoint you tried to call exists in the [specification](/v2/swagger).
+-   The `method` in the problem matches the one in the [specification](/v2/swagger).
+
+## Fields
+
+|           |                                                                                       |
+| --------- | ------------------------------------------------------------------------------------- |
+| `method`  | The requested method that is not allowed                                              |
+| `allowed` | List of all accepted methods for this endpoint. Same as provided the `Accept` header. |
+
+## Example
+
+```json
+{
+    "type": "/problems/request-method-not-allowed",
+    "title": "The requested method is not allowed.",
+    "status": 405,
+    "detail": "The requested resource does not support method 'PATCH', it does only support one of 'GET, POST, PUT, DELETE'.",
+    "method": "PATCH",
+    "allowed": ["GET", "POST", "PUT", "DELETE"]
+}
+```

--- a/server/gorillamux/problems/docs/route-not-found.md
+++ b/server/gorillamux/problems/docs/route-not-found.md
@@ -1,0 +1,16 @@
+[< Index](/problems)
+
+# The requested endpoint could not be found
+
+The request was unable to be routed to one of the [specified](/v2/swagger) endpoints.
+
+## Example
+
+```json
+{
+    "type": "/problems/route-not-found",
+    "title": "The requested endpoint could not be found.",
+    "status": 404,
+    "detail": "Ensure that the URI is a valid endpoint for the service."
+}
+```

--- a/server/gorillamux/problems/docs/route-not-found.md
+++ b/server/gorillamux/problems/docs/route-not-found.md
@@ -4,15 +4,6 @@
 
 The request was unable to be routed to one of the specified endpoints.
 
-## Fields
-
-|           |                                                                                       |
-| --------- | ------------------------------------------------------------------------------------- |
-| `type`    | Path to this page                                                                     |
-| `title`   | The title of this Problem                                                             |
-| `status`  | HTTP status code that is returned with this Problem                                   |
-| `detail`  | Message about why this Problem was returned                                           |
-
 ## Example
 
 ```json

--- a/server/gorillamux/problems/docs/route-not-found.md
+++ b/server/gorillamux/problems/docs/route-not-found.md
@@ -2,7 +2,16 @@
 
 # The requested endpoint could not be found
 
-The request was unable to be routed to one of the [specified](/v2/swagger) endpoints.
+The request was unable to be routed to one of the specified endpoints.
+
+## Fields
+
+|           |                                                                                       |
+| --------- | ------------------------------------------------------------------------------------- |
+| `type`    | Path to this page                                                                     |
+| `title`   | The title of this Problem                                                             |
+| `status`  | HTTP status code that is returned with this Problem                                   |
+| `detail`  | Message about why this Problem was returned                                           |
 
 ## Example
 

--- a/server/gorillamux/problems/methodnotfound.go
+++ b/server/gorillamux/problems/methodnotfound.go
@@ -1,0 +1,32 @@
+package problems
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/SKF/go-rest-utility/problems"
+)
+
+type MethodNotAllowedProblem struct {
+	problems.BasicProblem
+	Method  string   `json:"requested_method,omitempty"`
+	Allowed []string `json:"allowed_methods,omitempty"`
+}
+
+func MethodNotAllowed(requested string, allowed ...string) MethodNotAllowedProblem {
+	return MethodNotAllowedProblem{
+		BasicProblem: problems.BasicProblem{
+			Type:   "/problems/request-method-not-allowed",
+			Title:  "The requested method is not allowed.",
+			Status: http.StatusMethodNotAllowed,
+			Detail: fmt.Sprintf(
+				"The requested resource does not support method '%s', it does only support one of '%s'.",
+				requested,
+				strings.Join(allowed, ", "),
+			),
+		},
+		Method:  requested,
+		Allowed: allowed,
+	}
+}

--- a/server/gorillamux/problems/problems.go
+++ b/server/gorillamux/problems/problems.go
@@ -8,6 +8,21 @@ import (
 	"github.com/SKF/go-rest-utility/problems"
 )
 
+type NotFoundProblem struct {
+	problems.BasicProblem
+}
+
+func NotFound() NotFoundProblem {
+	return NotFoundProblem{
+		BasicProblem: problems.BasicProblem{
+			Type:   "/problems/route-not-found",
+			Title:  "The requested endpoint could not be found.",
+			Status: http.StatusNotFound,
+			Detail: "Ensure that the URI is a valid endpoint for the service.",
+		},
+	}
+}
+
 type MethodNotAllowedProblem struct {
 	problems.BasicProblem
 	Method  string   `json:"requested_method,omitempty"`

--- a/server/gorillamux/problems/problems.go
+++ b/server/gorillamux/problems/problems.go
@@ -25,8 +25,8 @@ func NotFound() NotFoundProblem {
 
 type MethodNotAllowedProblem struct {
 	problems.BasicProblem
-	Method  string   `json:"requested_method,omitempty"`
-	Allowed []string `json:"allowed_methods,omitempty"`
+	Method  string   `json:"requestedMethod,omitempty"`
+	Allowed []string `json:"allowedMethods,omitempty"`
 }
 
 func MethodNotAllowed(requested string, allowed ...string) MethodNotAllowedProblem {

--- a/server/gorillamux/problems/problems_test.go
+++ b/server/gorillamux/problems/problems_test.go
@@ -1,0 +1,44 @@
+package problems
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/SKF/go-rest-utility/problems"
+)
+
+func Test_MethodNotFoundHandler(t *testing.T) {
+	expectedProblem := MethodNotAllowedProblem{
+		BasicProblem: problems.BasicProblem{
+			Type:   "/problems/request-method-not-allowed",
+			Title:  "The requested method is not allowed.",
+			Status: http.StatusMethodNotAllowed,
+			Detail: fmt.Sprintf(
+				"The requested resource does not support method '%s', it does only support one of '%s'.",
+				"GET",
+				strings.Join([]string{"PUT", "PATCH"}, ", "),
+			),
+		},
+		Method:  "GET",
+		Allowed: []string{"PUT", "PATCH"},
+	}
+
+	assert.Equal(t, expectedProblem, MethodNotAllowed("GET", "PUT", "PATCH"))
+}
+
+func Test_NotFoundHandler(t *testing.T) {
+	expectedProblem := NotFoundProblem{
+		BasicProblem: problems.BasicProblem{
+			Type:   "/problems/route-not-found",
+			Title:  "The requested endpoint could not be found.",
+			Status: http.StatusNotFound,
+			Detail: "Ensure that the URI is a valid endpoint for the service.",
+		},
+	}
+
+	assert.Equal(t, expectedProblem, NotFound())
+}


### PR DESCRIPTION
A faulty MethodNotFoundHandler is used by many of our services running gorilla/mux. This fixes a nil reference and a try to remove copypasted code in the services. 