### PR TITLE
Add client Problem handling and better client error handling

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -17,4 +17,4 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.31
+          version: v1.41.1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,7 +30,7 @@ linters-settings:
 linters:
   enable:
     - bodyclose #- checks whether HTTP response body is closed successfully
-    - golint #- Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes
+    - revive #- Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint.
     - rowserrcheck #- checks whether Err of rows is checked successfully
     - stylecheck #- Stylecheck is a replacement for golint
     - gosec #- Inspects source code for security problems

--- a/client/client.go
+++ b/client/client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-http-utils/headers"
 
 	"github.com/SKF/go-rest-utility/client/auth"
+	"github.com/SKF/go-rest-utility/problems"
 )
 
 const (
@@ -100,7 +101,7 @@ func (c *Client) prepareRequest(ctx context.Context, req *Request) (*http.Reques
 }
 
 func (c *Client) prepareResponse(ctx context.Context, resp *http.Response) (*Response, error) {
-	if c.problemDecoder != nil && resp.Header.Get(headers.ContentType) == "application/problem+json" {
+	if c.problemDecoder != nil && resp.Header.Get(headers.ContentType) == problems.ContentType {
 		problem, err := c.problemDecoder.DecodeProblem(ctx, resp)
 		if err != nil {
 			return nil, fmt.Errorf("unable to decode http error into problem: %w", err)

--- a/client/client.go
+++ b/client/client.go
@@ -79,18 +79,6 @@ func (c *Client) prepareRequest(ctx context.Context, req *Request) (*http.Reques
 		return nil, fmt.Errorf("unable to create http request: %w", err)
 	}
 
-	/*
-		if req.body != nil && httpRequest.ContentLength <= 0 {
-			body, err := io.ReadAll(req.body)
-			if err != nil {
-				return nil, err
-			}
-
-			httpRequest.Body = io.NopCloser(bytes.NewReader(body))
-			httpRequest.ContentLength = int64(len(body))
-		}
-	*/
-
 	for header, defaultValue := range c.defaultHeaders {
 		if _, exists := req.header[header]; !exists {
 			req.header[header] = defaultValue

--- a/client/client.go
+++ b/client/client.go
@@ -18,8 +18,9 @@ const (
 )
 
 type Client struct {
-	BaseURL       *url.URL
-	TokenProvider auth.TokenProvider
+	BaseURL        *url.URL
+	TokenProvider  auth.TokenProvider
+	problemDecoder ProblemDecoder
 
 	client         *http.Client
 	defaultHeaders http.Header
@@ -30,6 +31,7 @@ func NewClient(opts ...Option) *Client {
 	client := &Client{
 		BaseURL:        nil,
 		TokenProvider:  nil,
+		problemDecoder: nil,
 		client:         new(http.Client),
 		defaultHeaders: make(http.Header),
 	}
@@ -55,7 +57,7 @@ func (c *Client) Do(ctx context.Context, r *Request) (*Response, error) {
 		return nil, fmt.Errorf("unable to perform http request: %w", err)
 	}
 
-	return c.prepareResponse(httpResponse)
+	return c.prepareResponse(ctx, httpResponse)
 }
 
 func (c *Client) DoAndUnmarshal(ctx context.Context, r *Request, v interface{}) error {
@@ -98,7 +100,16 @@ func (c *Client) prepareRequest(ctx context.Context, req *Request) (*http.Reques
 	return httpRequest, nil
 }
 
-func (c *Client) prepareResponse(resp *http.Response) (*Response, error) {
+func (c *Client) prepareResponse(ctx context.Context, resp *http.Response) (*Response, error) {
+	if c.problemDecoder != nil && resp.Header.Get(headers.ContentType) == "application/problem+json" {
+		problem, err := c.problemDecoder.DecodeProblem(ctx, resp)
+		if err != nil {
+			return nil, fmt.Errorf("unable to decode http error into problem: %w", err)
+		}
+
+		return nil, problem
+	}
+
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		defer resp.Body.Close()
 

--- a/client/errors.go
+++ b/client/errors.go
@@ -1,9 +1,100 @@
 package client
 
-import "errors"
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
 
 var (
-	ErrUnauthorized = errors.New("unauthorized")
-	ErrForbidden    = errors.New("forbidden")
-	ErrNotFound     = errors.New("not found")
+	ErrBadRequest                   = newHTTPError(http.StatusBadRequest)
+	ErrUnauthorized                 = newHTTPError(http.StatusUnauthorized)
+	ErrPaymentRequired              = newHTTPError(http.StatusPaymentRequired)
+	ErrForbidden                    = newHTTPError(http.StatusForbidden)
+	ErrNotFound                     = newHTTPError(http.StatusNotFound)
+	ErrMethodNotAllowed             = newHTTPError(http.StatusMethodNotAllowed)
+	ErrNotAcceptable                = newHTTPError(http.StatusNotAcceptable)
+	ErrProxyAuthRequired            = newHTTPError(http.StatusProxyAuthRequired)
+	ErrRequestTimeout               = newHTTPError(http.StatusRequestTimeout)
+	ErrConflict                     = newHTTPError(http.StatusConflict)
+	ErrGone                         = newHTTPError(http.StatusGone)
+	ErrLengthRequired               = newHTTPError(http.StatusLengthRequired)
+	ErrPreconditionFailed           = newHTTPError(http.StatusPreconditionFailed)
+	ErrRequestEntityTooLarge        = newHTTPError(http.StatusRequestEntityTooLarge)
+	ErrRequestURITooLong            = newHTTPError(http.StatusRequestURITooLong)
+	ErrUnsupportedMediaType         = newHTTPError(http.StatusUnsupportedMediaType)
+	ErrRequestedRangeNotSatisfiable = newHTTPError(http.StatusRequestedRangeNotSatisfiable)
+	ErrExpectationFailed            = newHTTPError(http.StatusExpectationFailed)
+	ErrTeapot                       = newHTTPError(http.StatusTeapot)
+	ErrMisdirectedRequest           = newHTTPError(http.StatusMisdirectedRequest)
+	ErrUnprocessableEntity          = newHTTPError(http.StatusUnprocessableEntity)
+	ErrLocked                       = newHTTPError(http.StatusLocked)
+	ErrFailedDependency             = newHTTPError(http.StatusFailedDependency)
+	ErrTooEarly                     = newHTTPError(http.StatusTooEarly)
+	ErrUpgradeRequired              = newHTTPError(http.StatusUpgradeRequired)
+	ErrPreconditionRequired         = newHTTPError(http.StatusPreconditionRequired)
+	ErrTooManyRequests              = newHTTPError(http.StatusTooManyRequests)
+	ErrRequestHeaderFieldsTooLarge  = newHTTPError(http.StatusRequestHeaderFieldsTooLarge)
+	ErrUnavailableForLegalReasons   = newHTTPError(http.StatusUnavailableForLegalReasons)
+
+	ErrInternalServerError           = newHTTPError(http.StatusInternalServerError)
+	ErrNotImplemented                = newHTTPError(http.StatusNotImplemented)
+	ErrBadGateway                    = newHTTPError(http.StatusBadGateway)
+	ErrServiceUnavailable            = newHTTPError(http.StatusServiceUnavailable)
+	ErrGatewayTimeout                = newHTTPError(http.StatusGatewayTimeout)
+	ErrHTTPVersionNotSupported       = newHTTPError(http.StatusHTTPVersionNotSupported)
+	ErrVariantAlsoNegotiates         = newHTTPError(http.StatusVariantAlsoNegotiates)
+	ErrInsufficientStorage           = newHTTPError(http.StatusInsufficientStorage)
+	ErrLoopDetected                  = newHTTPError(http.StatusLoopDetected)
+	ErrNotExtended                   = newHTTPError(http.StatusNotExtended)
+	ErrNetworkAuthenticationRequired = newHTTPError(http.StatusNetworkAuthenticationRequired)
 )
+
+type HTTPError struct {
+	StatusCode int
+	Status     string
+
+	Instance string
+	Body     string
+}
+
+func newHTTPError(statusCode int) HTTPError {
+	return HTTPError{
+		StatusCode: statusCode,
+		Status:     http.StatusText(statusCode),
+	}
+}
+
+func (e HTTPError) withInstance(instance string) HTTPError {
+	e.Instance = instance
+	return e
+}
+
+func (e HTTPError) withBody(reader io.ReadCloser) HTTPError {
+	defer reader.Close()
+
+	if body, err := io.ReadAll(reader); err == nil {
+		e.Body = string(body)
+	}
+
+	return e
+}
+
+func (e HTTPError) Error() string {
+	instanceText := ""
+	if len(e.Instance) != 0 {
+		instanceText = " for : " + e.Instance
+	}
+
+	bodyText := e.Body
+	if len(bodyText) == 0 {
+		bodyText = "[no body]"
+	}
+
+	return fmt.Sprintf("got %d%s: %s: %s", e.StatusCode, instanceText, bodyText, e.Status)
+}
+
+func (e HTTPError) Is(target error) bool {
+	httpErr, ok := target.(HTTPError)
+	return ok && httpErr.StatusCode == e.StatusCode
+}

--- a/client/errors_test.go
+++ b/client/errors_test.go
@@ -1,0 +1,37 @@
+package client_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/SKF/go-rest-utility/client"
+)
+
+func TestClientGet_NotFoundError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprintf(w, "a nice description on why teapots are bad")
+	}))
+	defer srv.Close()
+
+	request := client.Get("endpoint")
+
+	c := client.NewClient(client.WithBaseURL(srv.URL))
+
+	_, err := c.Do(context.Background(), request)
+	require.Error(t, err)
+
+	require.ErrorIs(t, err, client.ErrNotFound)
+
+	httpErr := client.HTTPError{}
+	require.ErrorAs(t, err, &httpErr)
+
+	require.Equal(t, http.StatusNotFound, httpErr.StatusCode)
+	require.Equal(t, "Not Found", httpErr.Status)
+	require.Equal(t, "a nice description on why teapots are bad", httpErr.Body)
+}

--- a/client/options.go
+++ b/client/options.go
@@ -33,7 +33,12 @@ func WithDefaultHeader(header, value string) Option {
 	}
 }
 
-// WithDatadogTracing will add an OpenCensus transport to the client
+func WithProblemDecoder(decoder ProblemDecoder) Option {
+	return func(c *Client) {
+		c.problemDecoder = decoder
+	}
+}
+
 // so that it will automatically inject trace-headers.
 //
 // Should be used when you trace your application with OpenCensus.

--- a/client/options.go
+++ b/client/options.go
@@ -39,6 +39,7 @@ func WithProblemDecoder(decoder ProblemDecoder) Option {
 	}
 }
 
+// WithOpenCensusTracing will add an OpenCensus transport to the client
 // so that it will automatically inject trace-headers.
 //
 // Should be used when you trace your application with OpenCensus.

--- a/client/problems.go
+++ b/client/problems.go
@@ -1,0 +1,27 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/SKF/go-rest-utility/problems"
+)
+
+type ProblemDecoder interface {
+	DecodeProblem(context.Context, *http.Response) (problems.Problem, error)
+}
+
+type BasicProblemDecoder struct{}
+
+func (d *BasicProblemDecoder) DecodeProblem(ctx context.Context, resp *http.Response) (problems.Problem, error) {
+	defer resp.Body.Close()
+
+	problem := problems.BasicProblem{}
+	if err := json.NewDecoder(resp.Body).Decode(&problem); err != nil {
+		return nil, fmt.Errorf("BasicProblem json decoder: %w", err)
+	}
+
+	return problem, nil
+}

--- a/client/problems_test.go
+++ b/client/problems_test.go
@@ -1,0 +1,104 @@
+package client_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/SKF/go-rest-utility/client"
+	"github.com/SKF/go-rest-utility/problems"
+)
+
+// The default client should not consider Problems for backward compatibility reasons
+// should probably be included in the default client in the next major version (v1).
+func TestClientGetWithoutProblemDecoder(t *testing.T) {
+	_, err := setupProblemServer(errors.New("internal error"))
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, client.ErrInternalServerError)
+}
+
+func TestClientGetWithBasicProblemDecoder(t *testing.T) {
+	expectedProblem := problems.BasicProblem{
+		Type:   "/my-basic-problem",
+		Title:  "A Basic Problem",
+		Status: http.StatusTeapot,
+		Detail: "What did you expect?",
+	}
+
+	_, err := setupProblemServer(expectedProblem, client.WithProblemDecoder(new(client.BasicProblemDecoder)))
+	require.Error(t, err)
+	require.Implements(t, (*problems.Problem)(nil), err)
+
+	actualProblem := err.(problems.Problem)
+	require.Equal(t, expectedProblem.Type, actualProblem.ProblemType())
+	require.Equal(t, expectedProblem.Status, actualProblem.ProblemStatus())
+	require.Equal(t, expectedProblem.Title, actualProblem.ProblemTitle())
+}
+
+func TestClientGetWithCustomProblemDecoder(t *testing.T) {
+	type CustomProblem struct {
+		problems.BasicProblem
+		Counter int
+	}
+
+	expectedProblem := CustomProblem{
+		BasicProblem: problems.BasicProblem{
+			Type:   "/my-custom-problem",
+			Title:  "An Custom Problem",
+			Status: http.StatusTeapot,
+			Detail: "What did you expect?",
+		},
+		Counter: 10,
+	}
+
+	var decoder ProblemDecoderFn = func(ctx context.Context, resp *http.Response) (problems.Problem, error) {
+		defer resp.Body.Close()
+
+		problem := CustomProblem{}
+		if err := json.NewDecoder(resp.Body).Decode(&problem); err != nil {
+			return nil, err
+		}
+
+		return problem, nil
+	}
+
+	_, err := setupProblemServer(expectedProblem, client.WithProblemDecoder(decoder))
+	require.Error(t, err)
+	require.IsType(t, expectedProblem, err)
+
+	actualProblem := err.(CustomProblem)
+	require.Equal(t, expectedProblem.Type, actualProblem.Type)
+	require.Equal(t, expectedProblem.Title, actualProblem.Title)
+	require.Equal(t, expectedProblem.Status, actualProblem.Status)
+	require.Equal(t, expectedProblem.Detail, actualProblem.Detail)
+	require.Equal(t, expectedProblem.Counter, actualProblem.Counter)
+}
+
+func setupProblemServer(problem error, opts ...client.Option) (*client.Response, error) { //nolint:unparam
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		problems.WriteResponse(r.Context(), problem, w, r)
+	}))
+	defer srv.Close()
+
+	request := client.Get("endpoint")
+
+	client := client.NewClient(
+		append([]client.Option{
+			client.WithBaseURL(srv.URL),
+		}, opts...)...,
+	)
+
+	return client.Do(context.Background(), request)
+}
+
+type ProblemDecoderFn func(context.Context, *http.Response) (problems.Problem, error)
+
+func (fn ProblemDecoderFn) DecodeProblem(ctx context.Context, resp *http.Response) (problems.Problem, error) {
+	return fn(ctx, resp)
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-http-utils/headers v0.0.0-20181008091004-fed159eddc2a
 	github.com/gorilla/mux v1.8.0
 	github.com/jtacoma/uritemplates v1.0.0
-	github.com/stretchr/testify v1.6.1
+	github.com/stretchr/testify v1.7.0
 	go.opencensus.io v0.22.5
 	gopkg.in/DataDog/dd-trace-go.v1 v1.27.1
 )

--- a/go.sum
+++ b/go.sum
@@ -103,6 +103,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tinylib/msgp v1.1.0/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tinylib/msgp v1.1.2 h1:gWmO7n0Ys2RBEb7GPYB9Ujq8Mk5p2U08lRnmMcGy6BQ=
 github.com/tinylib/msgp v1.1.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=

--- a/problems/basic.go
+++ b/problems/basic.go
@@ -71,7 +71,7 @@ func (problem *BasicProblem) DecorateWithRequest(ctx context.Context, r *http.Re
 	// the go-utility/log package in the WithTracing function.
 	if span := trace.FromContext(ctx); span != nil {
 		traceID := span.SpanContext().TraceID
-		problem.CorrelationID = strconv.FormatUint(binary.BigEndian.Uint64(traceID[8:]), 10)
+		problem.CorrelationID = strconv.FormatUint(binary.BigEndian.Uint64(traceID[8:]), 10) //nolint:gomnd
 	}
 
 	problem.Instance = r.URL.String()

--- a/problems/http.go
+++ b/problems/http.go
@@ -9,6 +9,8 @@ import (
 	"github.com/SKF/go-utility/v2/log"
 )
 
+const ContentType = "application/problem+json"
+
 // Generic, returns a generic HTTP-based Problem from a HTTP status code.
 func Generic(status int) Problem {
 	return BasicProblem{
@@ -38,7 +40,7 @@ func WriteResponse(ctx context.Context, err error, w http.ResponseWriter, r *htt
 		l.Info(problem.ProblemTitle())
 	}
 
-	w.Header().Set("Content-Type", "application/problem+json")
+	w.Header().Set("Content-Type", ContentType)
 	w.WriteHeader(statusCode)
 
 	if encodeErr := json.NewEncoder(w).Encode(problem); encodeErr != nil {


### PR DESCRIPTION
Adds the ability to decode Problems from the REST Client. This is not turn on by default for backward compatibility reasons. To enable add the following to your client options,
```go
client.WithProblemDecoder(new(client.BasicProblemDecoder))
```

This PR also includes an improvement in non-problem errors by exposing them through a new `HTTPError` struct.