### PR TITLE
Use problem interface instead of error interface when applicable

### DIFF
--- a/problems/validation.go
+++ b/problems/validation.go
@@ -19,7 +19,7 @@ func Validation(reasons ...ValidationReason) ValidationProblem {
 	}
 }
 
-func (problem ValidationProblem) TrimEmpty() error {
+func (problem ValidationProblem) TrimEmpty() Problem {
 	if len(problem.Reasons) == 0 {
 		return nil
 	}


### PR DESCRIPTION
Since Problems shouldn't be wrapped - they stop being problems then - I think it's appropriate to use the Problem interface whenever possible, to make it clear that an error have 'evolved' to it's next stage.

This change makes this approach a bit easier to implement