### PR TITLE
Feature/cached token provider

### DIFF
--- a/client/auth/cachedtokenprovider/cachedtokenprovider.go
+++ b/client/auth/cachedtokenprovider/cachedtokenprovider.go
@@ -1,0 +1,71 @@
+package cachedtokenprovider
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/SKF/go-utility/v2/auth/secretsmanagerauth"
+
+	"github.com/SKF/go-rest-utility/client/auth"
+)
+
+type Config struct {
+	secretsmanagerauth.Config
+	TokenTimeToLive time.Duration
+}
+
+type Provider struct {
+	config Config
+
+	serviceAccountToken string
+	lastRefreshTime     time.Time
+}
+
+// Ensure Provider implements auth.TokenProvider interface
+var _ auth.TokenProvider = Provider{}
+
+func New(config Config) *Provider {
+	secretsmanagerauth.Configure(config.Config)
+
+	return &Provider{
+		config:          config,
+		lastRefreshTime: time.Now(),
+	}
+}
+
+func (provider Provider) GetRawToken(ctx context.Context) (auth.RawToken, error) {
+	if err := provider.refresh(ctx); err != nil {
+		return "", fmt.Errorf("failed to refresh identity token: %w", err)
+	}
+
+	return auth.RawToken(provider.serviceAccountToken), nil
+}
+
+func (provider *Provider) refresh(ctx context.Context) error {
+	if provider.tokenIsUninitialized() || provider.tokenIsOutdated() {
+		if err := secretsmanagerauth.SignIn(ctx); err != nil {
+			return fmt.Errorf("unable to sign-in as service user '%s': %w", provider.config.SecretKey, err)
+		}
+
+		tokens := secretsmanagerauth.GetTokens()
+
+		if tokens.IdentityToken == "" {
+			return fmt.Errorf("identityToken was empty unexpectedly")
+		}
+
+		provider.serviceAccountToken = tokens.IdentityToken
+		provider.lastRefreshTime = time.Now()
+	}
+
+	return nil
+}
+
+func (provider Provider) tokenIsOutdated() bool {
+	timeToRefresh := provider.lastRefreshTime.Add(provider.config.TokenTimeToLive)
+	return time.Now().After(timeToRefresh)
+}
+
+func (provider Provider) tokenIsUninitialized() bool {
+	return provider.serviceAccountToken == ""
+}

--- a/client/auth/cachedtokenprovider/cachedtokenprovider_test.go
+++ b/client/auth/cachedtokenprovider/cachedtokenprovider_test.go
@@ -1,0 +1,82 @@
+package cachedtokenprovider_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	auth_model "github.com/SKF/go-utility/v2/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/SKF/go-rest-utility/client/auth/cachedtokenprovider"
+)
+
+const (
+	expectedToken = "my-token"
+)
+
+func Test_GetRawToken_HappyCase(t *testing.T) {
+	// Given
+	ctx := context.Background()
+	provider := cachedtokenprovider.NewWithCustomAuth(cachedtokenprovider.Config{}, &AuthStub{})
+
+	// When
+	token, err := provider.GetRawToken(ctx)
+
+	// Then
+	require.NoError(t, err)
+	assert.Equal(t, "my-token.0", string(token))
+}
+
+func Test_GetRawToken_NoNewTokenWithinTTL(t *testing.T) {
+	// Given
+	ctx := context.Background()
+	provider := cachedtokenprovider.NewWithCustomAuth(cachedtokenprovider.Config{
+		TokenTimeToLive: time.Minute,
+	}, &AuthStub{})
+
+	for i := 0; i < 10; i++ {
+		// When
+		token, err := provider.GetRawToken(ctx)
+
+		require.NoError(t, err)
+		assert.Equal(t, "my-token.0", string(token))
+	}
+}
+
+func Test_GetRawToken_NewTokenAfterTTL(t *testing.T) {
+	// Given
+	ctx := context.Background()
+	provider := cachedtokenprovider.NewWithCustomAuth(cachedtokenprovider.Config{
+		TokenTimeToLive: time.Millisecond,
+	}, &AuthStub{})
+
+	tokenBeforeTTL, err := provider.GetRawToken(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "my-token.0", string(tokenBeforeTTL))
+
+	time.Sleep(2 * time.Millisecond)
+
+	// When
+	token, err := provider.GetRawToken(ctx)
+
+	// Then
+	require.NoError(t, err)
+	assert.Equal(t, "my-token.1", string(token))
+}
+
+type AuthStub struct {
+	i int
+}
+
+func (stub *AuthStub) GetTokens(context.Context) (auth_model.Tokens, error) {
+	tokens := auth_model.Tokens{
+		IdentityToken: fmt.Sprintf("%s.%d", expectedToken, stub.i),
+	}
+
+	stub.i++
+
+	return tokens, nil
+}

--- a/client/auth/secretsmanagerauth/secretsmanagerauth.go
+++ b/client/auth/secretsmanagerauth/secretsmanagerauth.go
@@ -1,0 +1,26 @@
+package secretsmanagerauth
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/SKF/go-utility/v2/auth"
+	"github.com/SKF/go-utility/v2/auth/secretsmanagerauth"
+)
+
+type SecretsManagerAuth struct {
+	config secretsmanagerauth.Config
+}
+
+func New(config secretsmanagerauth.Config) SecretsManagerAuth {
+	secretsmanagerauth.Configure(config)
+	return SecretsManagerAuth{config: config}
+}
+
+func (sma SecretsManagerAuth) GetTokens(ctx context.Context) (auth.Tokens, error) {
+	if err := secretsmanagerauth.SignIn(ctx); err != nil {
+		return auth.Tokens{}, fmt.Errorf("unable to sign-in using secretKey '%s': %w", sma.config.SecretKey, err)
+	}
+
+	return secretsmanagerauth.GetTokens(), nil
+}


### PR DESCRIPTION
A token provider that works better with lambdas. Perhaps its sufficiently generic/useful to warrant a place in this library.

An attempt was made to isolate the logic, making it testable. It makes the solution a bit more involved though. An alternative would be keeping it simple, and testing live.