### PR TITLE
Add ability to emulate a clock in the cached token tests

### DIFF
--- a/client/auth/auth_test.go
+++ b/client/auth/auth_test.go
@@ -65,6 +65,14 @@ func encodeToBase64(v interface{}) (string, error) {
 	return buf.String(), nil
 }
 
+type FakeClock struct {
+	Now time.Time
+}
+
+func (fc *FakeClock) Get() time.Time {
+	return fc.Now
+}
+
 type SSO struct {
 	*httptest.Server
 


### PR DESCRIPTION
Reduces the flakiness of the `TestCachedTokenProvider_RefreshAfterTTL` test by not using `time.Sleep`