### PR TITLE
Fix auth.CredentialsTokenProvider handle non-json payloads

### DIFF
--- a/client/auth/auth_test.go
+++ b/client/auth/auth_test.go
@@ -124,6 +124,8 @@ func (api *SSO) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.Header().Set("Content-Type", "application/json")
+
 	user, found := api.users[request.Username]
 	if found {
 		user.calls++

--- a/client/auth/credentials.go
+++ b/client/auth/credentials.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -125,6 +126,15 @@ func (provider *CredentialsTokenProvider) signIn(ctx context.Context, creds Sign
 	}
 
 	defer rs.Body.Close()
+
+	if ct := rs.Header.Get("Content-Type"); ct != "application/json" {
+		body, err := io.ReadAll(rs.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed reading non json response: %w", err)
+		}
+
+		return nil, fmt.Errorf("unexpected content-type: %s %d: %s", ct, rs.StatusCode, body)
+	}
 
 	var response struct {
 		Data  SignInResponse


### PR DESCRIPTION
Returns better error messages when the SSO ALB is returning XML-based errors